### PR TITLE
add geocodeglib for addon, add PILLOW

### DIFF
--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -110,6 +110,8 @@ modules:
 
   - name: python3-bsddb
     buildsystem: simple
+    ensure-writable:
+      - /lib/python3.8/site-packages/easy-install.pth
     build-options:
       env:
         BERKELEYDB_DIR: /app

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -164,7 +164,7 @@ modules:
          url:  https://github.com/nzjrs/osm-gps-map/releases/download/1.1.0/osm-gps-map-1.1.0.tar.gz
          sha256:  8f2ff865ed9ed9786cc5373c37b341b876958416139d0065ebb785cf88d33586
 
-  # Gramps does not see geocodeglib in platform
+  # Gramps does not see geocodeglib in platform, needed for place coordinate addon
   - name: geocodeglibDependency
     buildsystem: meson
     sources:

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -164,6 +164,14 @@ modules:
          url:  https://github.com/nzjrs/osm-gps-map/releases/download/1.1.0/osm-gps-map-1.1.0.tar.gz
          sha256:  8f2ff865ed9ed9786cc5373c37b341b876958416139d0065ebb785cf88d33586
 
+  # Gramps does not see geocodeglib in platform
+  - name: geocodeglibDependency
+    buildsystem: meson
+    sources:
+      - type: archive
+        url:  https://gitlab.gnome.org/GNOME/geocode-glib/-/archive/master/geocode-glib-master.tar.gz
+        sha256:  46b961cee110b4175a62ef599bd3e590e7ef1e86a345de4e0c04ab74146eddbe
+
   - name: PyICUDependency
     buildsystem: simple
     ensure-writable:

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -23,6 +23,16 @@ finish-args:
 #needs network access for maps
   - --share=network
 modules:
+# PILLOW for cropping images, latex support, and addons
+  - name: PILLOWDependency
+    buildsystem: simple
+    build-commands:
+      - python3 setup.py install --prefix=/app
+    sources:
+      - type: archive
+        url:  https://files.pythonhosted.org/packages/73/59/3192bb3bc554ccbd678bdb32993928cb566dccf32f65dac65ac7e89eb311/Pillow-8.1.0.tar.gz
+        sha256:  887668e792b7edbfb1d3c9d8b5d8c859269a0f0eba4dda562adb95500f60dbba
+
 # following dependencies are for the GraphView Addon
   - name: PGIDependency
     buildsystem: simple


### PR DESCRIPTION
The geocodeglib in the Gnome Platform was not recognized by Gramps, so added manually for Place Coordinate addon
PILLOW added