### PR TITLE
change no-debuginfo to strip=true

### DIFF
--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -8,7 +8,7 @@ rename-icon: gramps
 rename-desktop-file: gramps.desktop
 # no-debuginfo to prevent Github Actions workflow from getting stuck, it causes errors
 build-options:
-  no-debuginfo: true
+  strip: true
 finish-args:
 # Gramps installs media files from backups to home, so it needs home access for now
 #  - --filesystem=xdg-documents


### PR DESCRIPTION
On the suggestion of @gasinvein changing to strip = true will make the flatpak smaller.  It has built twice on flathub gramps testing for both arm64 and amd64, so it appears to work so far.  I verified on a VM that the package runs.