### PR TITLE
gives create option for data directories

### DIFF
--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -12,9 +12,9 @@ finish-args:
   - --filesystem=xdg-pictures
 # for data directories and backwards compatibility  
   - --filesystem=~/.gramps:create
-  - --filesystem=xdg-data
-  - --filesystem=xdg-config
-  - --filesystem=xdg-cache
+  - --filesystem= ~/.config/gramps
+  - --filesystem=~/.cache/gramps
+  - --filesystem=~/.local/share/gramps
 # needs to own upstream name
   - --own-name=org.gramps-project.Gramps
 # for gui

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -12,6 +12,9 @@ finish-args:
   - --filesystem=xdg-pictures
 # for data directories and backwards compatibility  
   - --filesystem=~/.gramps:create
+  - --filesystem=~/.local/share:create
+  - --filesystem=~/.config:create
+  - --filesystem=~/.cache:create
 # needs to own upstream name
   - --own-name=org.gramps-project.Gramps
 # for gui

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -12,9 +12,6 @@ finish-args:
   - --filesystem=xdg-pictures
 # for data directories and backwards compatibility  
   - --filesystem=~/.gramps:create
-  - --filesystem= ~/.config/gramps
-  - --filesystem=~/.cache/gramps
-  - --filesystem=~/.local/share/gramps
 # needs to own upstream name
   - --own-name=org.gramps-project.Gramps
 # for gui


### PR DESCRIPTION
Since flathub fails manifests with xdg-data, xdg-cache, and xdg-config access, the directories had to be specifically named and given create permission. For example /.config:create so that a gramps directory can be created in the .config directory if it doesn't exist.